### PR TITLE
Add GitHub PR Agent example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# portia-agent-examples
-Examples from Portia Labs on using the SDK and cloud tool library to build multi agent systems
+# Portia Agent Examples
+
+Examples from Portia Labs on using the SDK and cloud tool library to build multi-agent systems.
+
+## Examples
+
+### [Get Started with Google Tools](./get_started_google_tools/README.md)
+A simple example showing how to use Portia with Google Workspace tools.
+
+### [Discord Knowledge Bot](./discord-knowledge-bot/README.md)
+A Discord bot that uses Portia to answer questions based on knowledge stored in a vector database.
+
+### [AI Research Agent](./ai-research-agent/README.md)
+An agent that reads AI-related emails and creates a podcast summary.
+
+### [GitHub PR Agent](./github-pr-agent/README.md)
+An agent that analyzes GitHub PRs, creates descriptions, provides code feedback, and comments on PRs.
+
+## Getting Started
+
+Each example has its own README with specific instructions. Generally, you'll need to:
+
+1. Clone this repository
+2. Navigate to the example directory
+3. Install dependencies (usually with pip or poetry)
+4. Set up environment variables in a `.env` file
+5. Run the example
+
+## License
+
+See the LICENSE file for details.

--- a/github-pr-agent/.env.example
+++ b/github-pr-agent/.env.example
@@ -1,0 +1,3 @@
+PORTIA_API_KEY="Replace with a key from app.portialabs.ai"
+OPENAI_API_KEY="Replace with a key from openai.com"
+GITHUB_TOKEN="Replace with a GitHub personal access token with repo scope"

--- a/github-pr-agent/README.md
+++ b/github-pr-agent/README.md
@@ -13,11 +13,14 @@ This agent:
 ## Setup
 
 1. Clone this repository
-2. Install dependencies:
+2. Install dependencies using Poetry:
    ```bash
    cd github-pr-agent
-   pip install -e .
+   poetry install
    ```
+   
+   If you don't have Poetry installed, you can install it following the instructions at [https://python-poetry.org/docs/#installation](https://python-poetry.org/docs/#installation)
+
 3. Create a `.env` file based on `.env.example` and fill in your API keys:
    ```
    PORTIA_API_KEY="your-portia-api-key"
@@ -25,14 +28,18 @@ This agent:
    GITHUB_TOKEN="your-github-personal-access-token"
    ```
    
-   Note: Your GitHub token needs to have the `repo` scope to read PRs and post comments.
+   To get these API keys:
+   - **PORTIA_API_KEY**: Sign up at [app.portialabs.ai](https://app.portialabs.ai) and create an API key
+   - **OPENAI_API_KEY**: Sign up at [platform.openai.com](https://platform.openai.com) and create an API key
+   - **GITHUB_TOKEN**: Go to [GitHub Settings > Developer settings > Personal access tokens](https://github.com/settings/tokens) and create a token with the `repo` scope to read PRs and post comments
 
 ## Usage
 
-Run the agent:
+Run the agent using Poetry:
 
 ```bash
-python agent.py
+cd github-pr-agent
+poetry run python agent.py
 ```
 
 The agent will:

--- a/github-pr-agent/README.md
+++ b/github-pr-agent/README.md
@@ -1,0 +1,53 @@
+# GitHub PR Agent
+
+A Portia agent that analyzes GitHub PRs and provides feedback.
+
+## Features
+
+This agent:
+1. Reads the latest PR for the portiaAI/platform repo
+2. Uses an LLM to create a description for it
+3. Uses an LLM to give feedback on the code
+4. Comments on the PR
+
+## Setup
+
+1. Clone this repository
+2. Install dependencies:
+   ```bash
+   cd github-pr-agent
+   pip install -e .
+   ```
+3. Create a `.env` file based on `.env.example` and fill in your API keys:
+   ```
+   PORTIA_API_KEY="your-portia-api-key"
+   OPENAI_API_KEY="your-openai-api-key"
+   GITHUB_TOKEN="your-github-personal-access-token"
+   ```
+   
+   Note: Your GitHub token needs to have the `repo` scope to read PRs and post comments.
+
+## Usage
+
+Run the agent:
+
+```bash
+python agent.py
+```
+
+The agent will:
+1. Get the latest PR from the portiaAI/platform repository
+2. Generate a description for the PR
+3. Analyze the code changes and provide feedback
+4. Post a comment on the PR with the description and feedback
+
+## Customization
+
+You can modify the `agent.py` file to:
+- Change the target repository (modify the `REPO` variable)
+- Adjust the analysis criteria
+- Change the LLM model used (modify the `config` setup)
+
+## License
+
+See the LICENSE file in the root of this repository.

--- a/github-pr-agent/agent.py
+++ b/github-pr-agent/agent.py
@@ -1,0 +1,98 @@
+"""
+GitHub PR Agent - A Portia agent that analyzes GitHub PRs and provides feedback.
+
+This agent:
+1. Reads the latest PR for the portiaAI/platform repo
+2. Uses an LLM to create a description for it
+3. Uses an LLM to give feedback on the code
+4. Comments on the PR
+"""
+
+import os
+import sys
+from dotenv import load_dotenv
+from portia import (
+    Config,
+    DefaultToolRegistry,
+    ExecutionContext,
+    LLMModel,
+    LogLevel,
+    PlanRunState,
+    Portia,
+    execution_context,
+)
+from portia.cli import CLIExecutionHooks
+from tools import github_pr_tool_registry
+
+# Load environment variables
+load_dotenv()
+
+# Check for required environment variables
+required_env_vars = ["PORTIA_API_KEY", "OPENAI_API_KEY", "GITHUB_TOKEN"]
+missing_vars = [var for var in required_env_vars if not os.getenv(var)]
+if missing_vars:
+    print(f"Error: Missing required environment variables: {', '.join(missing_vars)}")
+    print("Please set these variables in a .env file or in your environment.")
+    sys.exit(1)
+
+# Configure Portia
+config = Config.from_default(
+    llm_model_name=LLMModel.GPT_4_O,
+    default_log_level=LogLevel.DEBUG,
+)
+
+# Combine default tools with our custom GitHub PR tools
+tools = DefaultToolRegistry(config) + github_pr_tool_registry
+
+# Instantiate Portia
+portia = Portia(
+    config=config,
+    tools=tools,
+    execution_hooks=CLIExecutionHooks(),
+)
+
+# Define the repository to analyze
+REPO = "portiaAI/platform"
+
+# Define the task for Portia
+task = f"""
+Analyze the latest PR in the {REPO} GitHub repository by following these steps:
+1. Get the latest PR from the {REPO} repository
+2. Create a concise but informative description for the PR based on the changes
+3. Analyze the code changes and provide constructive feedback, including:
+   - Code quality assessment
+   - Potential bugs or issues
+   - Suggestions for improvements
+   - Any security concerns
+4. Post a comment on the PR with both the description and feedback
+"""
+
+# Execute the agent
+with execution_context(
+    end_user_id="github-pr-agent",
+):
+    # Generate the plan
+    print("\nGenerating plan...")
+    plan = portia.plan(task)
+    
+    print("\nHere are the steps in the generated plan:")
+    [print(step.model_dump_json(indent=2)) for step in plan.steps]
+    
+    # Ask for confirmation before executing the plan
+    if os.getenv("CI") != "true":
+        user_input = input("\nAre you happy with the plan? (y/n):\n")
+        if user_input.lower() != "y":
+            print("Exiting without executing the plan.")
+            sys.exit(0)
+    
+    # Execute the plan
+    print("\nExecuting the plan...")
+    run = portia.run_plan(plan)
+    
+    # Check if the plan completed successfully
+    if run.state != PlanRunState.COMPLETE:
+        print(f"Plan run failed with state {run.state}. Check logs for details.")
+        sys.exit(1)
+    
+    print("\nPlan executed successfully!")
+    print(f"Check the {REPO} repository for the PR comment.")

--- a/github-pr-agent/pyproject.toml
+++ b/github-pr-agent/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "github_pr_agent"
+version = "0.1.0"
+description = "A Portia agent that analyzes GitHub PRs and provides feedback"
+authors = ["Portia AI <hello@portialabs.ai>"]
+package-mode = false
+
+[tool.poetry.dependencies]
+python = "^3.11"
+portia-sdk-python = "^0.1.1"
+python-dotenv = "^1.0.1"
+PyGithub = "^2.2.0"
+
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/github-pr-agent/tools/__init__.py
+++ b/github-pr-agent/tools/__init__.py
@@ -1,0 +1,5 @@
+"""GitHub PR tools package."""
+
+from .registry import github_pr_tool_registry
+
+__all__ = ["github_pr_tool_registry"]

--- a/github-pr-agent/tools/comment_on_pr_tool.py
+++ b/github-pr-agent/tools/comment_on_pr_tool.py
@@ -1,0 +1,70 @@
+"""Tool to comment on a GitHub PR."""
+
+import os
+from pydantic import BaseModel, Field
+from portia.tool import Tool, ToolRunContext
+from github import Github, GithubException
+
+
+class CommentOnPRToolSchema(BaseModel):
+    """Schema defining the inputs for the CommentOnPRTool."""
+
+    repo: str = Field(
+        ...,
+        description="The repository containing the PR, in the format 'owner/repo'",
+    )
+    pr_number: int = Field(
+        ...,
+        description="The PR number to comment on",
+    )
+    comment: str = Field(
+        ...,
+        description="The comment text to post on the PR",
+    )
+
+
+class CommentOnPRTool(Tool[dict]):
+    """Comments on a GitHub PR."""
+
+    id: str = "comment_on_pr_tool"
+    name: str = "Comment on PR Tool"
+    description: str = "Comments on a GitHub PR"
+    args_schema: type[BaseModel] = CommentOnPRToolSchema
+    output_schema: tuple[str, str] = (
+        "dict",
+        "A dictionary containing information about the comment result",
+    )
+
+    def run(self, _: ToolRunContext, repo: str, pr_number: int, comment: str) -> dict:
+        """Run the CommentOnPRTool."""
+        
+        github_token = os.getenv("GITHUB_TOKEN")
+        if not github_token:
+            raise ValueError("GITHUB_TOKEN environment variable is not set")
+        
+        g = Github(github_token)
+        
+        try:
+            repository = g.get_repo(repo)
+            pr = repository.get_pull(pr_number)
+            
+            # Create a comment on the PR
+            comment_obj = pr.create_issue_comment(comment)
+            
+            return {
+                "success": True,
+                "comment_id": comment_obj.id,
+                "comment_url": comment_obj.html_url,
+                "created_at": comment_obj.created_at.isoformat()
+            }
+            
+        except GithubException as e:
+            return {
+                "success": False,
+                "error": f"GitHub API error: {str(e)}"
+            }
+        except Exception as e:
+            return {
+                "success": False,
+                "error": f"Unexpected error: {str(e)}"
+            }

--- a/github-pr-agent/tools/get_latest_pr_tool.py
+++ b/github-pr-agent/tools/get_latest_pr_tool.py
@@ -1,0 +1,74 @@
+"""Tool to get the latest PR from a GitHub repository."""
+
+import os
+from pydantic import BaseModel, Field
+from portia.tool import Tool, ToolRunContext
+from github import Github, GithubException
+
+
+class GetLatestPRToolSchema(BaseModel):
+    """Schema defining the inputs for the GetLatestPRTool."""
+
+    repo: str = Field(
+        ...,
+        description="The repository to get the latest PR from, in the format 'owner/repo'",
+    )
+
+
+class GetLatestPRTool(Tool[dict]):
+    """Gets the latest PR from a GitHub repository."""
+
+    id: str = "get_latest_pr_tool"
+    name: str = "Get Latest PR Tool"
+    description: str = "Gets the latest PR from a GitHub repository"
+    args_schema: type[BaseModel] = GetLatestPRToolSchema
+    output_schema: tuple[str, str] = (
+        "dict",
+        "A dictionary containing information about the latest PR",
+    )
+
+    def run(self, _: ToolRunContext, repo: str) -> dict:
+        """Run the GetLatestPRTool."""
+        
+        github_token = os.getenv("GITHUB_TOKEN")
+        if not github_token:
+            raise ValueError("GITHUB_TOKEN environment variable is not set")
+        
+        g = Github(github_token)
+        
+        try:
+            repository = g.get_repo(repo)
+            pulls = repository.get_pulls(state="open", sort="created", direction="desc")
+            
+            if pulls.totalCount == 0:
+                return {"error": "No open PRs found in the repository"}
+            
+            latest_pr = pulls[0]
+            
+            # Get the PR files
+            files = []
+            for file in latest_pr.get_files():
+                files.append({
+                    "filename": file.filename,
+                    "status": file.status,
+                    "additions": file.additions,
+                    "deletions": file.deletions,
+                    "changes": file.changes,
+                    "patch": file.patch
+                })
+            
+            return {
+                "pr_number": latest_pr.number,
+                "title": latest_pr.title,
+                "body": latest_pr.body,
+                "user": latest_pr.user.login,
+                "created_at": latest_pr.created_at.isoformat(),
+                "updated_at": latest_pr.updated_at.isoformat(),
+                "html_url": latest_pr.html_url,
+                "files": files
+            }
+            
+        except GithubException as e:
+            return {"error": f"GitHub API error: {str(e)}"}
+        except Exception as e:
+            return {"error": f"Unexpected error: {str(e)}"}

--- a/github-pr-agent/tools/registry.py
+++ b/github-pr-agent/tools/registry.py
@@ -1,0 +1,12 @@
+"""Registry containing GitHub PR tools."""
+
+from portia import InMemoryToolRegistry
+from .get_latest_pr_tool import GetLatestPRTool
+from .comment_on_pr_tool import CommentOnPRTool
+
+github_pr_tool_registry = InMemoryToolRegistry.from_local_tools(
+    [
+        GetLatestPRTool(),
+        CommentOnPRTool(),
+    ],
+)


### PR DESCRIPTION
This PR adds a new example agent that:

1. Reads the latest PR for the portiaAI/platform repo
2. Uses an LLM to create a description for it
3. Uses an LLM to give feedback on the code
4. Comments on the PR

The agent demonstrates how to create custom GitHub tools with Portia and how to use them to analyze and interact with GitHub PRs.