### PR TITLE
Add one conditinal if to process the refund

### DIFF
--- a/refund-agent-mcp/refund_agent.py
+++ b/refund-agent-mcp/refund_agent.py
@@ -181,7 +181,7 @@ def main(customer_email: str):
         plan = portia.plan(
             """
 Read the refund request email from the customer and decide if it should be approved or rejected.
-If you think the refund request should be approved, ALWAYS check with a human for final approval and then process the refund.
+If you think the refund request should be approved, ALWAYS check with a human for final approval and if approved then process the refund.
 
 Stripe instructions -- To create a refund in Stripe, you need to:
 * Find the Customer using their email address from the List of Customers in Stripe.


### PR DESCRIPTION


Add `if approved` condition to make sure planner understand the intent. Tested 10 times to make sure it's spitting out conditional on all other steps.

## Next Step 

 - Add this example to introspection evals to capture it.
 - As of now it usually SKIP every other step. Ideally, it should just stop and return COMPLETE. So will iterate on introspection agent to optimise this case more.
