### PR TITLE
PlanBuilderV2 version of Scheduler agent (#729)

### DIFF
--- a/ai-research-agent/main_with_plan_builder.py
+++ b/ai-research-agent/main_with_plan_builder.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+
+from dotenv import load_dotenv
+
+from portia import Config, DefaultToolRegistry, PlanBuilderV2, PlanRun, Portia, StepOutput
+from portia.cli import CLIExecutionHooks
+
+
+def _tomorrow_window() -> tuple[str, str]:
+    """Return ISO8601 start/end for tomorrow 10:00-17:00 local time."""
+    now = datetime.now()
+    tomorrow = now + timedelta(days=1)
+    start = tomorrow.replace(hour=10, minute=0, second=0, microsecond=0)
+    end = tomorrow.replace(hour=17, minute=0, second=0, microsecond=0)
+    return start.isoformat(), end.isoformat()
+
+
+def build_plan() -> PlanBuilderV2:
+    """Create a plan that checks calendar availability, schedules a meeting, and emails details.
+
+    Uses single-tool agent steps so Portia can handle tool argument planning, clarifications,
+    and Google auth flows via CLIExecutionHooks.
+    """
+    start_iso, end_iso = _tomorrow_window()
+
+    return (
+        PlanBuilderV2("Schedule meeting and email details")
+        .user_input(
+            message="Enter the recipient's email address for the meeting invite and follow-up: ",
+            step_name="Get Recipient Email",
+        )
+        .user_input(
+            message="Enter a meeting title (default: 'Portia AI Demo'): ",
+            step_name="Get Meeting Title",
+        )
+        .user_input(
+            message="Enter a short meeting description (default: 'Test demo'): ",
+            step_name="Get Meeting Description",
+        )
+        .single_tool_agent_step(
+            tool="portia:google:gcalendar:check_availability",
+            task=(
+                f"Check my Google Calendar availability tomorrow between {start_iso} and {end_iso}. "
+                "Return a list of open 30-minute slots."
+            ),
+            step_name="Check Availability",
+        )
+        .single_tool_agent_step(
+            tool="portia:google:gcalendar:create_event",
+            task=(
+                "Using the availability from the previous step, schedule a 30 minute meeting with "
+                f"{StepOutput('Get Recipient Email')} at the earliest suitable time. "
+                f"Use the title from {StepOutput('Get Meeting Title')} (default 'Portia AI Demo' if empty) "
+                f"and description from {StepOutput('Get Meeting Description')} (default 'Test demo' if empty). "
+                "Include the recipient as a guest."
+            ),
+            step_name="Create Event",
+        )
+        .user_verify(
+            message=(
+                "About to send an email confirmation with the event details. Proceed? "
+                f"Event ref: {StepOutput('Create Event')}"
+            ),
+            step_name="Confirm Email Send",
+        )
+        .single_tool_agent_step(
+            tool="portia:google:gmail:send_email",
+            task=(
+                "Send an email to the recipient with the details of the meeting that was just scheduled. "
+                f"To: {StepOutput('Get Recipient Email')}. "
+                f"Subject: Meeting scheduled - use {StepOutput('Get Meeting Title')} (default 'Portia AI Demo'). "
+                "Body: Include date/time, attendees, and calendar link from the created event."
+            ),
+            step_name="Send Email",
+        )
+        .final_output(summarize=True)
+    )
+
+
+async def main() -> PlanRun:
+    load_dotenv(override=True)
+
+    # Configure Portia with default cloud tools (includes Google tools) and CLI clarifications.
+    cfg = Config.from_default()
+    portia = Portia(config=cfg, tools=DefaultToolRegistry(cfg), execution_hooks=CLIExecutionHooks())
+
+    plan = build_plan().build()
+    return await portia.arun_plan(plan)
+
+
+if __name__ == "__main__":
+    result = asyncio.run(main())
+    print(result.model_dump_json(indent=2))
+

--- a/ai-research-agent/main_with_plan_builder.py
+++ b/ai-research-agent/main_with_plan_builder.py
@@ -83,7 +83,6 @@ def build_plan() -> PlanBuilderV2:
 async def main() -> PlanRun:
     load_dotenv(override=True)
 
-    # Configure Portia with default cloud tools (includes Google tools) and CLI clarifications.
     cfg = Config.from_default()
     portia = Portia(config=cfg, tools=DefaultToolRegistry(cfg), execution_hooks=CLIExecutionHooks())
 

--- a/ai-research-agent/pyproject.toml
+++ b/ai-research-agent/pyproject.toml
@@ -3,9 +3,9 @@ name = "ai_research_agent"
 version = "0.1.0"
 description = "A toy agent to receive and summarise AI news emails"
 authors = [{ name = "Portia AI", email = "hello@portialabs.ai" }]
-requires-python = "~=3.13"
+requires-python = "~=3.13.0"
 dependencies = [
-    "portia-sdk-python>=0.6.2,<0.7",
+    "portia-sdk-python>=0.7.0",
     "python-dotenv>=1.0.1,<2",
     "podcastfy>=0.4.1,<0.5",
     "audioop-lts>=0.2.1,<0.3",

--- a/ai-research-agent/uv.lock
+++ b/ai-research-agent/uv.lock
@@ -1,6 +1,6 @@
 version = 1
-revision = 2
-requires-python = ">=3.13, <4"
+revision = 3
+requires-python = "==3.13.*"
 
 [[package]]
 name = "ai-research-agent"
@@ -19,7 +19,7 @@ dependencies = [
 requires-dist = [
     { name = "audioop-lts", specifier = ">=0.2.1,<0.3" },
     { name = "podcastfy", specifier = ">=0.4.1,<0.5" },
-    { name = "portia-sdk-python", specifier = ">=0.6.2,<0.7" },
+    { name = "portia-sdk-python", specifier = ">=0.7.0" },
     { name = "py-cord", specifier = ">=2.6.1" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },
     { name = "tornado", specifier = ">=6.5.0" },
@@ -205,7 +205,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/55/07/f0b3375bf0d06014e9787797e6b7cc02b38ac9ff9726ccfe834d94e9991e/backrefs-5.9-py311-none-any.whl", hash = "sha256:6907635edebbe9b2dc3de3a2befff44d74f30a4562adbb8b36f21252ea19c5cf", size = 392072, upload-time = "2025-06-22T19:34:06.743Z" },
     { url = "https://files.pythonhosted.org/packages/9d/12/4f345407259dd60a0997107758ba3f221cf89a9b5a0f8ed5b961aef97253/backrefs-5.9-py312-none-any.whl", hash = "sha256:7fdf9771f63e6028d7fee7e0c497c81abda597ea45d6b8f89e8ad76994f5befa", size = 397947, upload-time = "2025-06-22T19:34:08.172Z" },
     { url = "https://files.pythonhosted.org/packages/10/bf/fa31834dc27a7f05e5290eae47c82690edc3a7b37d58f7fb35a1bdbf355b/backrefs-5.9-py313-none-any.whl", hash = "sha256:cc37b19fa219e93ff825ed1fed8879e47b4d89aa7a1884860e2db64ccd7c676b", size = 399843, upload-time = "2025-06-22T19:34:09.68Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/24/b29af34b2c9c41645a9f4ff117bae860291780d73880f449e0b5d948c070/backrefs-5.9-py314-none-any.whl", hash = "sha256:df5e169836cc8acb5e440ebae9aad4bf9d15e226d3bad049cf3f6a5c20cc8dc9", size = 411762, upload-time = "2025-06-22T19:34:11.037Z" },
     { url = "https://files.pythonhosted.org/packages/41/ff/392bff89415399a979be4a65357a41d92729ae8580a66073d8ec8d810f98/backrefs-5.9-py39-none-any.whl", hash = "sha256:f48ee18f6252b8f5777a22a00a09a85de0ca931658f1dd96d4406a34f3748c60", size = 380265, upload-time = "2025-06-22T19:34:12.405Z" },
 ]
 
@@ -840,7 +839,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/79/e0/1bb90d30b5450eac2dffeaac6b692857c4bd642c21883b79faa8fa056cf2/greenlet-3.2.1-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:51a2f49da08cff79ee42eb22f1658a2aed60c72792f0a0a95f5f0ca6d101b1fb", size = 593687, upload-time = "2025-04-22T14:25:59.676Z" },
     { url = "https://files.pythonhosted.org/packages/c5/b5/adbe03c8b4c178add20cc716021183ae6b0326d56ba8793d7828c94286f6/greenlet-3.2.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:0c68bbc639359493420282d2f34fa114e992a8724481d700da0b10d10a7611b8", size = 1105754, upload-time = "2025-04-22T14:59:02.585Z" },
     { url = "https://files.pythonhosted.org/packages/39/93/84582d7ef38dec009543ccadec6ab41079a6cbc2b8c0566bcd07bf1aaf6c/greenlet-3.2.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:e775176b5c203a1fa4be19f91da00fd3bff536868b77b237da3f4daa5971ae5d", size = 1125160, upload-time = "2025-04-22T14:28:13.975Z" },
-    { url = "https://files.pythonhosted.org/packages/01/e6/f9d759788518a6248684e3afeb3691f3ab0276d769b6217a1533362298c8/greenlet-3.2.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d6668caf15f181c1b82fb6406f3911696975cc4c37d782e19cb7ba499e556189", size = 269897, upload-time = "2025-04-22T14:27:14.044Z" },
 ]
 
 [[package]]
@@ -1975,7 +1973,7 @@ wheels = [
 
 [[package]]
 name = "portia-sdk-python"
-version = "0.6.2"
+version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
@@ -1992,6 +1990,7 @@ dependencies = [
     { name = "litellm" },
     { name = "loguru" },
     { name = "mcp" },
+    { name = "openai" },
     { name = "openpyxl" },
     { name = "pandas" },
     { name = "posthog" },
@@ -2000,9 +1999,9 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "testcontainers", extra = ["redis"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/86/1f03f81256014f19309dfc972a195ffac4cdd1ea7aa21532f0b885a6e32e/portia_sdk_python-0.6.2.tar.gz", hash = "sha256:0dc204bacacf9614be4b7368e918ace4812061acfa6ce0194f5944da16beaced", size = 138218, upload-time = "2025-08-14T13:04:59.664Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/c5/559a8a8f234d9465b99d28b92f47236afa3c903d54700c9558794d9356ff/portia_sdk_python-0.7.3.tar.gz", hash = "sha256:904c7e0a66f512d6d37f7860dbf21184a753755e0aba964c689349dc7fd61a3e", size = 158561, upload-time = "2025-08-28T11:32:44.653Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/6e/3fd4134687d7c7322bed9642553efb672139319640bb32050d8d54a1cca9/portia_sdk_python-0.6.2-py3-none-any.whl", hash = "sha256:809d1b9941604cdf91810fe48566d5852d257aed1d1c8ea9f07d2037cae36b3f", size = 173483, upload-time = "2025-08-14T13:04:58.065Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/9b/b4b7a3c4ca5ab48b5705f08caac1b59b40aeb43caf76af18c968b1e77545/portia_sdk_python-0.7.3-py3-none-any.whl", hash = "sha256:66aae52838c0c1edb9cc5964c3bcd6de44c8026fcc767fe85b09cc080eda7317", size = 197255, upload-time = "2025-08-28T11:32:43.086Z" },
 ]
 
 [[package]]
@@ -2800,7 +2799,7 @@ name = "sqlalchemy"
 version = "2.0.40"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "greenlet", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64') or (python_full_version < '3.14' and platform_machine == 'WIN32') or (python_full_version < '3.14' and platform_machine == 'aarch64') or (python_full_version < '3.14' and platform_machine == 'amd64') or (python_full_version < '3.14' and platform_machine == 'ppc64le') or (python_full_version < '3.14' and platform_machine == 'win32') or (python_full_version < '3.14' and platform_machine == 'x86_64')" },
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/68/c3/3f2bfa5e4dcd9938405fe2fab5b6ab94a9248a4f9536ea2fd497da20525f/sqlalchemy-2.0.40.tar.gz", hash = "sha256:d827099289c64589418ebbcaead0145cd19f4e3e8a93919a0100247af245fa00", size = 9664299, upload-time = "2025-03-27T17:52:31.876Z" }

--- a/ai-research-agent/uv.lock
+++ b/ai-research-agent/uv.lock
@@ -205,6 +205,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/55/07/f0b3375bf0d06014e9787797e6b7cc02b38ac9ff9726ccfe834d94e9991e/backrefs-5.9-py311-none-any.whl", hash = "sha256:6907635edebbe9b2dc3de3a2befff44d74f30a4562adbb8b36f21252ea19c5cf", size = 392072, upload-time = "2025-06-22T19:34:06.743Z" },
     { url = "https://files.pythonhosted.org/packages/9d/12/4f345407259dd60a0997107758ba3f221cf89a9b5a0f8ed5b961aef97253/backrefs-5.9-py312-none-any.whl", hash = "sha256:7fdf9771f63e6028d7fee7e0c497c81abda597ea45d6b8f89e8ad76994f5befa", size = 397947, upload-time = "2025-06-22T19:34:08.172Z" },
     { url = "https://files.pythonhosted.org/packages/10/bf/fa31834dc27a7f05e5290eae47c82690edc3a7b37d58f7fb35a1bdbf355b/backrefs-5.9-py313-none-any.whl", hash = "sha256:cc37b19fa219e93ff825ed1fed8879e47b4d89aa7a1884860e2db64ccd7c676b", size = 399843, upload-time = "2025-06-22T19:34:09.68Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/24/b29af34b2c9c41645a9f4ff117bae860291780d73880f449e0b5d948c070/backrefs-5.9-py314-none-any.whl", hash = "sha256:df5e169836cc8acb5e440ebae9aad4bf9d15e226d3bad049cf3f6a5c20cc8dc9", size = 411762, upload-time = "2025-06-22T19:34:11.037Z" },
     { url = "https://files.pythonhosted.org/packages/41/ff/392bff89415399a979be4a65357a41d92729ae8580a66073d8ec8d810f98/backrefs-5.9-py39-none-any.whl", hash = "sha256:f48ee18f6252b8f5777a22a00a09a85de0ca931658f1dd96d4406a34f3748c60", size = 380265, upload-time = "2025-06-22T19:34:12.405Z" },
 ]
 
@@ -839,6 +840,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/79/e0/1bb90d30b5450eac2dffeaac6b692857c4bd642c21883b79faa8fa056cf2/greenlet-3.2.1-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:51a2f49da08cff79ee42eb22f1658a2aed60c72792f0a0a95f5f0ca6d101b1fb", size = 593687, upload-time = "2025-04-22T14:25:59.676Z" },
     { url = "https://files.pythonhosted.org/packages/c5/b5/adbe03c8b4c178add20cc716021183ae6b0326d56ba8793d7828c94286f6/greenlet-3.2.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:0c68bbc639359493420282d2f34fa114e992a8724481d700da0b10d10a7611b8", size = 1105754, upload-time = "2025-04-22T14:59:02.585Z" },
     { url = "https://files.pythonhosted.org/packages/39/93/84582d7ef38dec009543ccadec6ab41079a6cbc2b8c0566bcd07bf1aaf6c/greenlet-3.2.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:e775176b5c203a1fa4be19f91da00fd3bff536868b77b237da3f4daa5971ae5d", size = 1125160, upload-time = "2025-04-22T14:28:13.975Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e6/f9d759788518a6248684e3afeb3691f3ab0276d769b6217a1533362298c8/greenlet-3.2.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d6668caf15f181c1b82fb6406f3911696975cc4c37d782e19cb7ba499e556189", size = 269897, upload-time = "2025-04-22T14:27:14.044Z" },
 ]
 
 [[package]]
@@ -1973,7 +1975,7 @@ wheels = [
 
 [[package]]
 name = "portia-sdk-python"
-version = "0.7.3"
+version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
@@ -1990,7 +1992,6 @@ dependencies = [
     { name = "litellm" },
     { name = "loguru" },
     { name = "mcp" },
-    { name = "openai" },
     { name = "openpyxl" },
     { name = "pandas" },
     { name = "posthog" },
@@ -1999,9 +2000,9 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "testcontainers", extra = ["redis"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/c5/559a8a8f234d9465b99d28b92f47236afa3c903d54700c9558794d9356ff/portia_sdk_python-0.7.3.tar.gz", hash = "sha256:904c7e0a66f512d6d37f7860dbf21184a753755e0aba964c689349dc7fd61a3e", size = 158561, upload-time = "2025-08-28T11:32:44.653Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/86/1f03f81256014f19309dfc972a195ffac4cdd1ea7aa21532f0b885a6e32e/portia_sdk_python-0.6.2.tar.gz", hash = "sha256:0dc204bacacf9614be4b7368e918ace4812061acfa6ce0194f5944da16beaced", size = 138218, upload-time = "2025-08-14T13:04:59.664Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/9b/b4b7a3c4ca5ab48b5705f08caac1b59b40aeb43caf76af18c968b1e77545/portia_sdk_python-0.7.3-py3-none-any.whl", hash = "sha256:66aae52838c0c1edb9cc5964c3bcd6de44c8026fcc767fe85b09cc080eda7317", size = 197255, upload-time = "2025-08-28T11:32:43.086Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/6e/3fd4134687d7c7322bed9642553efb672139319640bb32050d8d54a1cca9/portia_sdk_python-0.6.2-py3-none-any.whl", hash = "sha256:809d1b9941604cdf91810fe48566d5852d257aed1d1c8ea9f07d2037cae36b3f", size = 173483, upload-time = "2025-08-14T13:04:58.065Z" },
 ]
 
 [[package]]
@@ -2799,7 +2800,7 @@ name = "sqlalchemy"
 version = "2.0.40"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "greenlet", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64') or (python_full_version < '3.14' and platform_machine == 'WIN32') or (python_full_version < '3.14' and platform_machine == 'aarch64') or (python_full_version < '3.14' and platform_machine == 'amd64') or (python_full_version < '3.14' and platform_machine == 'ppc64le') or (python_full_version < '3.14' and platform_machine == 'win32') or (python_full_version < '3.14' and platform_machine == 'x86_64')" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/68/c3/3f2bfa5e4dcd9938405fe2fab5b6ab94a9248a4f9536ea2fd497da20525f/sqlalchemy-2.0.40.tar.gz", hash = "sha256:d827099289c64589418ebbcaead0145cd19f4e3e8a93919a0100247af245fa00", size = 9664299, upload-time = "2025-03-27T17:52:31.876Z" }


### PR DESCRIPTION
Add ai-research-agent/main_with_plan_builder.py built with PlanBuilderV2

Ticket: https://github.com/portiaAI/portia-sdk-python/issues/729

- Integrates Google Calendar (check availability, create event) and Gmail (send email)
- Uses DefaultToolRegistry and CLIExecutionHooks for auth and clarifications
- Prompts for recipient email, meeting title, description.
- Defaults to tomorrow 10:00–17:00 window and a 30-minute slot if times are omitted
- Provides a concise final summary and prints the plan run JSON

What it does

- Collects meeting details from the user.
- Checks Google Calendar availability within the provided or default window.
- Creates a 30-minute event with the recipient as a guest.
- Asks for user confirmation before emailing.
- Sends a confirmation email via Gmail with event details.
- Displays the full plan run result (inputs, step outputs, final output, summary).

Video Link : https://drive.google.com/file/d/1dyA7u4NYo1UzWv-Vhz2AZfAeXhX-7gBx/view?usp=sharing

How to run

- cd portia-agent-examples/ai-research-agent
- uv run python main_with_plan_builder.py